### PR TITLE
Use Native Semantics

### DIFF
--- a/ssi/utility-header.html
+++ b/ssi/utility-header.html
@@ -17,7 +17,7 @@
             <div class="half settings-links">
                 <ul class="utility-links ">
                     <li><a href="">Contact Us</a></li>
-                    <li><a type="button" data-toggle="collapse" href="#siteSettings" aria-expanded="false" aria-controls="siteSettings"><span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings</a></li>
+                    <li><button class="btn btn-primary" data-toggle="collapse" data-target="#siteSettings" aria-expanded="false" aria-controls="siteSettings"><i class="ca-gov-icon-gear" aria-hidden="true"></i> Settings</button>                   
                    
                 </ul>
             </div>

--- a/ssi/utility-header.html
+++ b/ssi/utility-header.html
@@ -17,7 +17,7 @@
             <div class="half settings-links">
                 <ul class="utility-links ">
                     <li><a href="">Contact Us</a></li>
-                    <li><a role="button" data-toggle="collapse" href="#siteSettings" aria-expanded="false" aria-controls="siteSettings"><span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings</a></li>
+                    <li><a type="button" data-toggle="collapse" href="#siteSettings" aria-expanded="false" aria-controls="siteSettings"><span class="ca-gov-icon-gear" aria-hidden="true"></span> Settings</a></li>
                    
                 </ul>
             </div>


### PR DESCRIPTION
This element has a `role` attribute even though native semantics are available. This meets strict accessibility standards.